### PR TITLE
Update ImportJSON.gs to remove excess rows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Karsten Lettow
 pbazerque
 Rafal (kenorb)
 Luis Lobo Borobia
+Jack Carey

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Here are all the functions available:
 Review `ImportJSON.gs` for more info on how to use these in detail.
 
 ## Version
+
+- v1.5.1 (March 3, 2019) jackcarey. Added cache_check_ function to ImportJSONAdvanced to cut down on fetches. Quick fix can enable custom age and tryProps values
+- v1.5.0  (January 11, 2019) Adds ability to include all headers in a fixed order even when no data is present for a given header in some or all rows.
 - v1.4.0 (July 23, 2017) - Project transferred to Brad Jasper. Fixed off-by-one array bug. Fixed previous value bug. Added custom annotations. Added ImportJSONFromSheet and ImportJSONBasicAuth.
 - v1.3.0 - Adds ability to import the text from a set of rows containing the text to parse. All cells are concatenated
 - v1.2.1 - Fixed a bug with how nested arrays are handled. The rowIndex counter wasn't incrementing properly when parsing.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Review `ImportJSON.gs` for more info on how to use these in detail.
 - v1.0.0 - Initial release
 
 ## How can you help?
-- Found a bug? Report it! https://github.com/bradjasper/ImportJSON/issues
-- Want to contribute? Submit an <a href="https://github.com/bradjasper/ImportJSON/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement">enhancement</a>
+- Found a bug? Report it! https://github.com/jackcarey/ImportJSON/issues
+- Want to contribute? Submit an <a href="https://github.com/jackcarey/ImportJSON/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement">enhancement</a>
 
 ## Website archive
 This code base used to be hosted at http://blog.fastfedora.com/projects/import-json and contained a lot of useful information. It has been archived at https://rawgit.com/bradjasper/ImportJSON/master/archive/blog.fastfedora.com/projects/import-json.html


### PR DESCRIPTION
Added duplicate row removal at final stage of parseJSONObject_. Users can specify a column number containing unique identifiers for each row. The de-duping code from 337 to 373 works backwards through the parsed array to fill in missing data, then removes matching rows that contain less data than those with the same identifier.