### PR TITLE
Update ImportJSON.gs

### DIFF
--- a/ImportJSON.gs
+++ b/ImportJSON.gs
@@ -473,7 +473,7 @@ function includeXPath_(query, path, options) {
  * Returns true if the rule applies to the given path. 
  */
 function applyXPathRule_(rule, path, options) {
-  return path.indexOf(rule) == 0; 
+  return path.indexOf(rule) == 0 && path.match(rule + "($|/)");
 }
 
 /** 


### PR DESCRIPTION
Currently, asking for /response/foo will also pull in /response/foobar .  (This is an issue with the openUV API, for example.)

This change adds an additional check so it will pull in /response/foo and response/foo/* but not /response/foobar .